### PR TITLE
Update for 6.6+ kernel issues

### DIFF
--- a/driver/ch343.c
+++ b/driver/ch343.c
@@ -845,7 +845,11 @@ static void ch343_tty_close(struct tty_struct *tty, struct file *filp)
 	tty_port_close(&ch343->port, tty, filp);
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0))
+static long int ch343_tty_write(struct tty_struct *tty, const unsigned char *buf, long unsigned int count)
+#else
 static int ch343_tty_write(struct tty_struct *tty, const unsigned char *buf, int count)
+#endif
 {
 	struct ch343 *ch343 = tty->driver_data;
 	int stat;


### PR DESCRIPTION
Updated the types in the ch343_tty_write declaration for kernel 6.6 compatibility mentioned in issue 32,  tested on 6.6.9 and 6.6.10 arch linux , with arduino and esp32 dev board.  