### PR TITLE
unaligned.sh moved from asm/ to linux/ in kernel 6.12.0

### DIFF
--- a/driver/ch343.c
+++ b/driver/ch343.c
@@ -52,7 +52,12 @@
 #include <linux/usb/cdc.h>
 #include <linux/version.h>
 #include <asm/byteorder.h>
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0))
 #include <linux/sched/signal.h>


### PR DESCRIPTION
In kernel 6.12.0 the `unaligned.h` header is in the generic `linux/` include folder.  This fixes compilation on that kernel series (and seems to work).